### PR TITLE
removed "remove button" from tab-order for easier input

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ const addColumn = () => {
 
     domColumns.appendChild(h('li.column', {}, [
         h('input.inColumn', { type: 'text' }),
-        h('button.btnRemove', {}, 'Remove')
+        h('button.btnRemove', {tabIndex: '-1'}, 'Remove')
     ]));
 };
 

--- a/script.js
+++ b/script.js
@@ -47,8 +47,8 @@ const addColumn = () => {
     if (!domColumns) { return null; }
 
     domColumns.appendChild(h('li.column', {}, [
-        h('input.inColumn', { type: 'text' }),
-        h('button.btnRemove', {tabIndex: '-1'}, 'Remove')
+        h('input.inColumn', { type: 'text', tabIndex: '1' }),
+        h('button.btnRemove', {tabIndex: '10'}, 'Remove')
     ]));
 };
 


### PR DESCRIPTION
This change means that pressing <kbd>tab</kbd> while a column input text field is active, the next column input field is selected and if you press <kbd>shift</kbd>+<kbd>tab</kbd> you get the previous. When all the input fields have been traversed, the remove buttons are traversed, and then the add button and the solve button.

Functionality has been tested in Firefox and Chrome on Windows and Linux.

Without this patch you need to hit <kbd>tab</kbd> (or <kbd>shift</kbd>+<kbd>tab</kbd>) twice.